### PR TITLE
Fix Mako Unicode Issue

### DIFF
--- a/specializers/array_doubler/array_doubler.py
+++ b/specializers/array_doubler/array_doubler.py
@@ -7,7 +7,7 @@ class ArrayDoubler(object):
 
     def double_using_template(self, arr):
         import asp.codegen.templating.template as template
-        mytemplate = template.Template(filename="templates/double_template.mako")
+        mytemplate = template.Template(filename="templates/double_template.mako", disable_unicode=True)
         rendered = mytemplate.render(num_items=len(arr))
 
         import asp.jit.asp_module as asp_module


### PR DESCRIPTION
Following the instructions at:

http://www.makotemplates.org/docs/unicode.html#saying-to-heck-with-it-disabling-the-usage-of-unicode-entirely

will use str by default. For the future maybe we want to wrap this with a decorator so specializer writers get this behavior by default?
