### PR TITLE
Adds support for print

### DIFF
--- a/asp/codegen/ast_tools.py
+++ b/asp/codegen/ast_tools.py
@@ -73,6 +73,9 @@ class ConvertAST(ast.NodeTransformer):
     def visit_Num(self, node):
         return CNumber(node.n)
 
+    def visit_Str(self, node):
+        return String(node.s)
+
     def visit_Name(self, node):
         return CName(node.id)
 
@@ -149,7 +152,13 @@ class ConvertAST(ast.NodeTransformer):
                 return TypeCast(Value('int', ''), self.visit(node.args[0]))
             if node.func.id == "abs":
                 return Call(CName("abs"), [self.visit(x) for x in node.args])
-        
+
+    def visit_Print(self, node):
+        text = str(self.visit(node.values[0])) if len(node.values) > 0 else ''
+        for fragment in node.values[1:]:
+            text += ' << \" \" << ' + str(self.visit(fragment))
+        return Print(text, node.nl)
+
 
 class LoopUnroller(object):
     class UnrollReplacer(NodeTransformer):

--- a/asp/codegen/cpp_ast.py
+++ b/asp/codegen/cpp_ast.py
@@ -25,6 +25,13 @@ class CNumber(Generable):
             raise ValueError
         yield self.__str__()
 
+class String(Generable):
+    def __init__(self, text):
+        self.text = text
+
+    def generate(self):
+        yield '\"%s\"' % self.text
+
 class CName(Generable):
     def __init__(self, name):
         self.name = name
@@ -309,3 +316,13 @@ class FunctionCall(codepy.cgen.Generable):
     def __str__(self):
         return "%s(%s)" % (self.fname, ','.join(map(str, self.params)))
 
+class Print(Generable):
+    def __init__(self, text, newline):
+        self.text = text
+        self.newline = newline
+
+    def generate(self):
+        if self.newline:
+            yield 'std::cout << %s << std::endl;' % self.text
+        else:
+            yield 'std::cout << %s;' % self.text


### PR DESCRIPTION
Adds support for Python's print. A specializer that uses this still needs to include iostream on their own.

It handles the comma behavior just as Python does. It doesn't support replacement like printf-style strings.
