### PR TITLE
moving if (and compare) support to asp

### DIFF
--- a/asp/codegen/ast_tools.py
+++ b/asp/codegen/ast_tools.py
@@ -164,6 +164,22 @@ class ConvertAST(ast.NodeTransformer):
             text += ' << \" \" << ' + str(self.visit(fragment))
         return Print(text, node.nl)
 
+    def visit_Compare(self, node):
+        # only handles 1 thing on right side for now (1st op and comparator)
+        # also currently not handling: Is, IsNot, In, NotIn
+        ops = {'Eq':'==','NotEq':'!=','Lt':'<','LtE':'<=','Gt':'>','GtE':'>='}
+        op = ops[node.ops[0].__class__.__name__]
+        return Compare(self.visit(node.left), op, self.visit(node.comparators[0]))
+
+    def visit_If(self, node):
+        test = self.visit(node.test)
+        body = Block([self.visit(x) for x in node.body])
+        if node.orelse == []:
+            orelse = None
+        else:
+            orelse = Block([self.visit(x) for x in node.orelse])
+        return IfConv(test, body, orelse)
+
 
 class LoopUnroller(object):
     class UnrollReplacer(NodeTransformer):

--- a/asp/codegen/cpp_ast.py
+++ b/asp/codegen/cpp_ast.py
@@ -365,4 +365,16 @@ class Print(Generable):
         else:
             yield 'std::cout %s;' % self.text
 
+class Compare(Generable):
+    def __init__(self, left, op, right):
+        self.left = left
+        self.op = op
+        self.right = right
+        self._fields = ('left', 'op', 'right')
 
+    def generate(self, with_semicolon=False):
+        yield '%s %s %s' % (self.left, self.op, self.right)
+
+class IfConv(If):
+    def generate(self, with_semicolon=False):
+        return super(IfConv, self).generate()


### PR DESCRIPTION
This is basic support for if statements and comparisons. To make comparisons more robust to multiple comparators, I think it would be best done in a process step. This can be done best once we have our own process class in asp that inherits from ast.NodeTransformer rather than each specializer writer inheriting from it.
